### PR TITLE
Add prisma validation to CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           cd backend
           npx prisma validate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Build backend
         run: |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,25 @@
+# Environment Configuration
+NODE_ENV=development
+PORT=3000
+
+# Database Configuration
+DATABASE_URL="postgresql://postgres:postgres@localhost:5555/postgres?schema=public"
+
+# Authentication Configuration
+BETTER_AUTH_SECRET=some-random-secret-key
+BETTER_AUTH_URL=http://localhost:5173
+
+# Log Cleanup Configuration
+LOG_CLEANUP_ENABLED=true
+LOG_CLEANUP_DAYS_TO_KEEP=30
+LOG_CLEANUP_SCHEDULE=@daily
+
+DB_SEED_ENABLED=true
+DB_SEED_FORCE_RESEED=false
+
+ATHLETE_SYNC_ENABLED=true
+ATHLETE_SYNC_SCHEDULE=@hourly
+
+LBFA_URL='http://the-lbfa-url.com'
+LBFA_USERNAME=some-username
+LBFA_PASSWORD=some-password

--- a/backend/src/lib/env.ts
+++ b/backend/src/lib/env.ts
@@ -23,6 +23,7 @@ const envSchema = z.object({
   ATHLETE_SYNC_SCHEDULE: z
     .enum(['@daily', '@hourly', '@weekly'])
     .default('@daily'),
+    
   LBFA_URL: z.url(),
   LBFA_USERNAME: z.string(),
   LBFA_PASSWORD: z.string(),


### PR DESCRIPTION
## Summary
- update code quality workflow to validate Prisma schema before building the backend

## Testing
- `npm run build` in `core`
- `npm run build` in `backend`
- `npm run lint` and `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68500ba052ec8329b33fd3b191f7a625