### PR TITLE
Filter competitions by published status

### DIFF
--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -23,7 +23,9 @@ competitionsRoutes.get(
   async (c) => {
     try {
       const { upcoming, past, organizationId } = c.req.valid('query');
-      const where: Prisma.CompetitionWhereInput = {};
+      const where: Prisma.CompetitionWhereInput = {
+        isPublished: true,
+      };
       const now = new Date();
 
       if (upcoming && !past) {


### PR DESCRIPTION
## Summary
- only return published competitions in the GET `/competitions` endpoint

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68505238f31483298d2dd08e7e79bf78