### PR TITLE
Add clubs CRUD routes

### DIFF
--- a/backend/prisma/migrations/20250617123221_remove_clubs_competitions_relation/migration.sql
+++ b/backend/prisma/migrations/20250617123221_remove_clubs_competitions_relation/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_ClubToCompetition` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_ClubToCompetition" DROP CONSTRAINT "_ClubToCompetition_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_ClubToCompetition" DROP CONSTRAINT "_ClubToCompetition_B_fkey";
+
+-- DropTable
+DROP TABLE "_ClubToCompetition";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -223,7 +223,6 @@ model Club {
   fedAbbr           String?
 
   athletesInfo      AthleteInfo[]
-  competitions      Competition[]
   freeCompetitions  Competition[] @relation("FreeClubsToCompetitions")
   allowedCompetitions   Competition[] @relation("AllowedClubsToCompetitions")
   // inscriptions     Inscription[]
@@ -314,7 +313,6 @@ model Competition {
 
   events              CompetitionEvent[]
   athletes            Athlete[]
-  clubs               Club[]
   // inscriptions        Inscription[]
   // results             Result[]
 

--- a/backend/src/routes/clubs.ts
+++ b/backend/src/routes/clubs.ts
@@ -100,7 +100,6 @@ clubsRoutes.delete(
 
       const dependencies = await prisma.$transaction([
         prisma.athleteInfo.count({ where: { clubId: id } }),
-        prisma.competition.count({ where: { clubs: { some: { id } } } }),
         prisma.competition.count({ where: { freeClubs: { some: { id } } } }),
         prisma.competition.count({ where: { allowedClubs: { some: { id } } } }),
       ]);

--- a/backend/src/routes/clubs.ts
+++ b/backend/src/routes/clubs.ts
@@ -1,0 +1,124 @@
+import { prisma } from '@/lib/prisma';
+import { requireAdmin } from '@/middleware/auth';
+import { logError } from '@/utils/log-utils';
+import { Club$, ClubCreate$, ClubUpdate$ } from '@competition-manager/core/schemas';
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { z } from 'zod/v4';
+
+const clubsRoutes = new Hono();
+
+// GET /clubs - Get all clubs (public)
+clubsRoutes.get('/', async (c) => {
+  try {
+    const clubs = await prisma.club.findMany({
+      orderBy: { abbr: 'asc' },
+    });
+    return c.json(Club$.array().parse(clubs));
+  } catch (error) {
+    logError('Failed to fetch clubs', error, c);
+    return c.json({ error: 'Failed to fetch clubs' }, 500);
+  }
+});
+
+// GET /clubs/:id - Get club by ID (public)
+clubsRoutes.get(
+  '/:id',
+  zValidator('param', z.object({ id: Club$.shape.id })),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param');
+      const club = await prisma.club.findUnique({
+        where: { id },
+      });
+      if (!club) {
+        return c.json({ error: 'Club not found' }, 404);
+      }
+      return c.json(Club$.parse(club));
+    } catch (error) {
+      logError('Failed to fetch club', error, c);
+      return c.json({ error: 'Failed to fetch club' }, 500);
+    }
+  }
+);
+
+// POST /clubs - Create new club (admin only)
+clubsRoutes.post(
+  '/',
+  requireAdmin,
+  zValidator('json', ClubCreate$),
+  async (c) => {
+    try {
+      const data = c.req.valid('json');
+      const club = await prisma.club.create({ data });
+      return c.json(Club$.parse(club), 201);
+    } catch (error) {
+      logError('Failed to create club', error, c);
+      return c.json({ error: 'Failed to create club' }, 500);
+    }
+  }
+);
+
+// PUT /clubs/:id - Update club (admin only)
+clubsRoutes.put(
+  '/:id',
+  requireAdmin,
+  zValidator('param', z.object({ id: Club$.shape.id })),
+  zValidator('json', ClubUpdate$),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param');
+      const data = c.req.valid('json');
+
+      const existingClub = await prisma.club.findUnique({ where: { id } });
+      if (!existingClub) {
+        return c.json({ error: 'Club not found' }, 404);
+      }
+
+      const club = await prisma.club.update({ where: { id }, data });
+      return c.json(Club$.parse(club));
+    } catch (error) {
+      logError('Failed to update club', error, c);
+      return c.json({ error: 'Failed to update club' }, 500);
+    }
+  }
+);
+
+// DELETE /clubs/:id - Delete club (admin only)
+clubsRoutes.delete(
+  '/:id',
+  requireAdmin,
+  zValidator('param', z.object({ id: Club$.shape.id })),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param');
+
+      const existingClub = await prisma.club.findUnique({ where: { id } });
+      if (!existingClub) {
+        return c.json({ error: 'Club not found' }, 404);
+      }
+
+      const dependencies = await prisma.$transaction([
+        prisma.athleteInfo.count({ where: { clubId: id } }),
+        prisma.competition.count({ where: { clubs: { some: { id } } } }),
+        prisma.competition.count({ where: { freeClubs: { some: { id } } } }),
+        prisma.competition.count({ where: { allowedClubs: { some: { id } } } }),
+      ]);
+
+      if (dependencies.some((count) => count > 0)) {
+        return c.json(
+          { error: 'Cannot delete club with associated records' },
+          400
+        );
+      }
+
+      await prisma.club.delete({ where: { id } });
+      return c.json({ message: 'Club deleted successfully' });
+    } catch (error) {
+      logError('Failed to delete club', error, c);
+      return c.json({ error: 'Failed to delete club' }, 500);
+    }
+  }
+);
+
+export { clubsRoutes };

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,7 @@ import { authRoutes } from './auth';
 import { categoriesRoutes } from './categories';
 import { competitionsRoutes } from './competitions';
 import { eventsRoutes } from './events';
+import { clubsRoutes } from './clubs';
 import { logsRoutes } from './logs';
 import { organizationRoutes } from './organization';
 
@@ -20,6 +21,7 @@ export function createApiRoutes() {
   api.route('/auth', authRoutes);
   api.route('/events', eventsRoutes);
   api.route('/categories', categoriesRoutes);
+  api.route('/clubs', clubsRoutes);
   api.route('/competitions', competitionsRoutes);
   api.route('/organization', organizationRoutes);
 

--- a/core/src/schemas/club.ts
+++ b/core/src/schemas/club.ts
@@ -13,3 +13,11 @@ export const Club$ = z.object({
   fedAbbr: z.string().nullish(),
 });
 export type Club = z.infer<typeof Club$>;
+
+// Club create schema (omit id)
+export const ClubCreate$ = Club$.omit({ id: true });
+export type ClubCreate = z.infer<typeof ClubCreate$>;
+
+// Club update schema (all fields optional except id)
+export const ClubUpdate$ = ClubCreate$.partial();
+export type ClubUpdate = z.infer<typeof ClubUpdate$>;


### PR DESCRIPTION
## Summary
- add ClubCreate and ClubUpdate schemas
- implement CRUD API routes for clubs
- expose clubs routes through API router

## Testing
- `npm test --silent` in core
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_68515b0b231083299608da0f27fc40b6