### PR TITLE
Add user seeding service

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ LOG_CLEANUP_SCHEDULE=@daily
 # Database seeding
 DB_SEED_ENABLED=true
 DB_SEED_FORCE_RESEED=false
+DB_SEED_USERS_ENABLED=false
+DB_SEED_ADMIN_EMAIL=admin@example.com
+DB_SEED_ADMIN_PASSWORD=admin123
+DB_SEED_USER_EMAIL=user@example.com
+DB_SEED_USER_PASSWORD=user123
 
 # Athlete sync with LBFA (Belgian Athletics Federation)
 ATHLETE_SYNC_ENABLED=true

--- a/backend/src/lib/env.ts
+++ b/backend/src/lib/env.ts
@@ -17,6 +17,13 @@ const envSchema = z.object({
   // Database seeding configuration
   DB_SEED_ENABLED: z.stringbool().default(true),
   DB_SEED_FORCE_RESEED: z.stringbool().default(false),
+  DB_SEED_USERS_ENABLED: z.stringbool().default(false),
+  DB_SEED_ADMIN_EMAIL: z.string().optional(),
+  DB_SEED_ADMIN_PASSWORD: z.string().optional(),
+  DB_SEED_ADMIN_NAME: z.string().default('Admin'),
+  DB_SEED_USER_EMAIL: z.string().optional(),
+  DB_SEED_USER_PASSWORD: z.string().optional(),
+  DB_SEED_USER_NAME: z.string().default('User'),
 
   // Athlete sync configuration
   ATHLETE_SYNC_ENABLED: z.stringbool().default(true),

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -5,10 +5,12 @@ import { AthleteSyncService } from './athlete-sync';
 import { LogCleanupService } from './log-cleanup';
 import { scheduler } from './scheduler';
 import { SeedService } from './seed';
+import { UserSeedService } from './user-seed';
 
 export class ServiceManager {
   private logCleanupService: LogCleanupService;
   private seedService: SeedService;
+  private userSeedService: UserSeedService;
   private athleteSyncService: AthleteSyncService;
   private isInitialized = false;
   private prodLogger: Logger | null = null;
@@ -24,6 +26,10 @@ export class ServiceManager {
     this.seedService = new SeedService({
       enabled: env.DB_SEED_ENABLED,
       forceReseed: env.DB_SEED_FORCE_RESEED,
+    });
+
+    this.userSeedService = new UserSeedService({
+      enabled: env.DB_SEED_USERS_ENABLED,
     });
 
     this.athleteSyncService = new AthleteSyncService({
@@ -54,6 +60,7 @@ export class ServiceManager {
       // Initialize log cleanup service
       this.logCleanupService.initialize(); // Initialize database seeding
       await this.seedService.initialize();
+      await this.userSeedService.initialize();
 
       // Initialize athlete sync service
       await this.athleteSyncService.initialize();
@@ -102,6 +109,10 @@ export class ServiceManager {
   getSeedService(): SeedService {
     return this.seedService;
   }
+
+  getUserSeedService(): UserSeedService {
+    return this.userSeedService;
+  }
   /**
    * Get athlete sync service instance for manual operations
    */
@@ -119,6 +130,7 @@ export class ServiceManager {
         scheduler: this.isInitialized,
         logCleanup: this.logCleanupService.getConfig().enabled,
         seeding: this.seedService.getConfig().enabled,
+        userSeeding: this.userSeedService.getConfig().enabled,
         athleteSync: this.athleteSyncService.getConfig().enabled,
       },
     };

--- a/backend/src/services/user-seed.ts
+++ b/backend/src/services/user-seed.ts
@@ -1,0 +1,88 @@
+import { env } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { prisma } from '@/lib/prisma';
+import { auth } from '@/lib/auth';
+import { UserRole$ } from '@competition-manager/core/schemas';
+import type { Logger } from 'winston';
+
+export interface UserSeedConfig {
+  enabled: boolean;
+}
+
+export class UserSeedService {
+  private config: UserSeedConfig;
+  private prodLogger: Logger | null = null;
+
+  constructor(config: UserSeedConfig) {
+    this.config = config;
+    if (env.NODE_ENV === 'production') {
+      this.prodLogger = logger;
+    }
+  }
+
+  async initialize(): Promise<{ created: number; skipped: number } | null> {
+    if (!this.config.enabled) {
+      this.prodLogger?.info('User seeding disabled');
+      return null;
+    }
+    this.prodLogger?.info('Starting user seeding...');
+    const result = await this.seedUsers();
+    this.prodLogger?.info('User seeding completed', result);
+    return result;
+  }
+
+  private async seedUsers(): Promise<{ created: number; skipped: number }> {
+    const seeds = [
+      {
+        email: env.DB_SEED_ADMIN_EMAIL,
+        password: env.DB_SEED_ADMIN_PASSWORD,
+        name: env.DB_SEED_ADMIN_NAME || 'Admin',
+        role: UserRole$.enum.admin,
+      },
+      {
+        email: env.DB_SEED_USER_EMAIL,
+        password: env.DB_SEED_USER_PASSWORD,
+        name: env.DB_SEED_USER_NAME || 'User',
+        role: UserRole$.enum.user,
+      },
+    ];
+
+    let created = 0;
+    let skipped = 0;
+
+    for (const seed of seeds) {
+      if (!seed.email || !seed.password) {
+        logger.warn('Missing credentials for seed user', { email: seed.email });
+        skipped++;
+        continue;
+      }
+
+      const existing = await prisma.user.findUnique({
+        where: { email: seed.email },
+      });
+
+      if (existing) {
+        skipped++;
+        continue;
+      }
+
+      await auth.api.admin.createUser({
+        body: {
+          email: seed.email,
+          password: seed.password,
+          name: seed.name,
+          role: seed.role,
+        },
+        use: [],
+      });
+
+      created++;
+    }
+
+    return { created, skipped };
+  }
+
+  getConfig(): UserSeedConfig {
+    return { ...this.config };
+  }
+}

--- a/backend/test/user-seed.test.ts
+++ b/backend/test/user-seed.test.ts
@@ -1,0 +1,56 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { UserSeedService } from '@/services/user-seed';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { env } from '@/lib/env';
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      admin: {
+        createUser: vi.fn().mockResolvedValue({}),
+      },
+    },
+  },
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    DB_SEED_ADMIN_EMAIL: 'admin@example.com',
+    DB_SEED_ADMIN_PASSWORD: 'pass',
+    DB_SEED_ADMIN_NAME: 'Admin',
+    DB_SEED_USER_EMAIL: 'user@example.com',
+    DB_SEED_USER_PASSWORD: 'pass',
+    DB_SEED_USER_NAME: 'User',
+    NODE_ENV: 'development',
+  },
+}));
+
+describe('UserSeedService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates users when they do not exist', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    const service = new UserSeedService({ enabled: true });
+    const result = await service.initialize();
+    expect(result).toEqual({ created: 2, skipped: 0 });
+    expect(auth.api.admin.createUser).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips existing users', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: '1' } as any);
+    const service = new UserSeedService({ enabled: true });
+    const result = await service.initialize();
+    expect(result).toEqual({ created: 0, skipped: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- seed a default admin and user when enabled by env vars
- expose user seeding service in ServiceManager
- document new env vars
- cover user seeding service with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c154a2948329a592a3e9d5082a77