### PR TITLE
Display published competitions

### DIFF
--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -1,8 +1,9 @@
-import { type Prisma } from '@/lib/prisma';
+import { prisma, type Prisma } from '@/lib/prisma';
 import { getCompetitions } from '@/utils/competition-utils';
 import { logError } from '@/utils/log-utils';
 import { zValidator } from '@hono/zod-validator';
-import { CompetitionQuery$ } from '@repo/core/schemas';
+import { Competition$, competitionInclude, CompetitionQuery$, Cuid$ } from '@repo/core/schemas';
+import { z } from 'zod/v4';
 import { Hono } from 'hono';
 
 const competitionsRoutes = new Hono();
@@ -37,6 +38,30 @@ competitionsRoutes.get(
     } catch (error) {
       logError('Failed to fetch competitions', error, c);
       return c.json({ error: 'Failed to fetch competitions' }, 500);
+    }
+  }
+);
+
+// GET /competitions/:eid - Get single competition details (public)
+competitionsRoutes.get(
+  '/:eid',
+  zValidator('param', z.object({ eid: Cuid$ })),
+  async (c) => {
+    try {
+      const { eid } = c.req.valid('param');
+      const competition = await prisma.competition.findFirst({
+        where: { eid, isPublished: true },
+        include: competitionInclude,
+      });
+
+      if (!competition) {
+        return c.json({ error: 'Competition not found' }, 404);
+      }
+
+      return c.json(Competition$.parse(competition));
+    } catch (error) {
+      logError('Failed to fetch competition', error, c);
+      return c.json({ error: 'Failed to fetch competition' }, 500);
     }
   }
 );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -237,10 +237,6 @@ const router = createBrowserRouter([
         element: <CompetitionDetailPage />,
       },
       {
-        path: 'participants',
-        element: <div>Participants</div>,
-      },
-      {
         path: 'results',
         element: <ResultsPage />,
       },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,16 @@ const pageImports = {
     import('./pages/SignIn').then((m) => ({ default: m.SignInPage })),
   SignUp: () =>
     import('./pages/SignUp').then((m) => ({ default: m.SignUpPage })),
+  Competitions: () =>
+    import('./pages/Competitions').then((m) => ({
+      default: m.CompetitionsPage,
+    })),
+  Results: () =>
+    import('./pages/Results').then((m) => ({ default: m.ResultsPage })),
+  CompetitionDetail: () =>
+    import('./pages/CompetitionDetail').then((m) => ({
+      default: m.CompetitionDetailPage,
+    })),
 
   // Admin pages
   AdminDashboard: () =>
@@ -115,6 +125,9 @@ const Home = createLazyComponent('Home');
 const NotFound = createLazyComponent('NotFound');
 const SignInPage = createLazyComponent('SignIn');
 const SignUpPage = createLazyComponent('SignUp');
+const CompetitionsPage = createLazyComponent('Competitions');
+const ResultsPage = createLazyComponent('Results');
+const CompetitionDetailPage = createLazyComponent('CompetitionDetail');
 
 const AdminDashboard = createLazyComponent('AdminDashboard');
 const AdminUsers = createLazyComponent('AdminUsers');
@@ -217,7 +230,11 @@ const router = createBrowserRouter([
       },
       {
         path: 'competitions',
-        element: <div>Competitions</div>,
+        element: <CompetitionsPage />,
+      },
+      {
+        path: 'competitions/:eid',
+        element: <CompetitionDetailPage />,
       },
       {
         path: 'participants',
@@ -225,7 +242,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'results',
-        element: <div>Results</div>,
+        element: <ResultsPage />,
       },
       {
         path: 'auth/sign-in',

--- a/frontend/src/features/competitions/components/competitions-list.tsx
+++ b/frontend/src/features/competitions/components/competitions-list.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+import type { Competition } from '@repo/core/schemas';
+
+interface CompetitionsListProps {
+  competitions: Competition[];
+  isLoading?: boolean;
+}
+
+export function CompetitionsList({ competitions, isLoading }: CompetitionsListProps) {
+  if (isLoading) {
+    return <div className="py-4 text-center">Loading competitions...</div>;
+  }
+
+  if (competitions.length === 0) {
+    return (
+      <div className="py-4 text-center text-muted-foreground">
+        No competitions found
+      </div>
+    );
+  }
+
+  const formatDate = (date: Date) =>
+    new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(date));
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {competitions.map((comp) => (
+        <Link
+          key={comp.id}
+          to={`/competitions/${comp.eid}`}
+          className="rounded-lg border p-4 hover:bg-muted/50"
+        >
+          <h3 className="font-semibold">{comp.name}</h3>
+          <p className="text-sm text-muted-foreground">
+            {formatDate(comp.startDate)} &bull; {comp.organization.name}
+          </p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/competitions/hooks/use-competitions.ts
+++ b/frontend/src/features/competitions/hooks/use-competitions.ts
@@ -1,4 +1,4 @@
-import type { Competition, CompetitionCreate } from '@repo/core/schemas';
+import type { Competition, CompetitionCreate, CompetitionQuery } from '@repo/core/schemas';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { CompetitionsService } from '../services/competitions-service';
@@ -22,10 +22,18 @@ export function useCreateCompetition() {
   });
 }
 
-export function useCompetitions() {
+export function useCompetitions(query?: Partial<CompetitionQuery>) {
   return useQuery<Competition[]>({
-    queryKey: [COMPETITIONS_QUERY_KEY],
-    queryFn: CompetitionsService.getCompetitions,
+    queryKey: [COMPETITIONS_QUERY_KEY, query],
+    queryFn: () => CompetitionsService.getCompetitions(query),
+  });
+}
+
+export function useCompetition(eid?: string) {
+  return useQuery<Competition | undefined>({
+    queryKey: [COMPETITIONS_QUERY_KEY, 'detail', eid],
+    queryFn: () => (eid ? CompetitionsService.getCompetition(eid) : Promise.resolve(undefined)),
+    enabled: Boolean(eid),
   });
 }
 

--- a/frontend/src/features/competitions/index.ts
+++ b/frontend/src/features/competitions/index.ts
@@ -1,8 +1,10 @@
 export { CreateCompetitionDialog } from './components/create-competition-dialog';
 export { CompetitionsTable } from './components/competitions-table';
+export { CompetitionsList } from './components/competitions-list';
 export {
   useCreateCompetition,
   useCompetitions,
   useOrganizationCompetitions,
+  useCompetition,
 } from './hooks/use-competitions';
 export { useOrganizationCompetition } from './hooks/use-competition';

--- a/frontend/src/features/competitions/services/competitions-service.ts
+++ b/frontend/src/features/competitions/services/competitions-service.ts
@@ -1,11 +1,22 @@
 import { apiClient } from '@/lib/api-client';
-import type { CompetitionCreate, Cuid } from '@repo/core/schemas';
+import type {
+  CompetitionCreate,
+  CompetitionQuery,
+  Cuid,
+} from '@repo/core/schemas';
 import { Competition$ } from '@repo/core/schemas';
 
 export class CompetitionsService {
-  static async getCompetitions() {
-    const response = await apiClient.get('/api/competitions');
+  static async getCompetitions(query?: Partial<CompetitionQuery>) {
+    const response = await apiClient.get('/api/competitions', {
+      params: query,
+    });
     return Competition$.array().parse(response.data);
+  }
+
+  static async getCompetition(eid: string) {
+    const response = await apiClient.get(`/api/competitions/${eid}`);
+    return Competition$.parse(response.data);
   }
 
   static async getOrganizationCompetitions() {
@@ -15,7 +26,7 @@ export class CompetitionsService {
 
   static async getOrganizationCompetition(eid: Cuid) {
     const response = await apiClient.get(
-      `/api/organization/competitions/${eid}`,
+      `/api/organization/competitions/${eid}`
     );
     return Competition$.parse(response.data);
   }

--- a/frontend/src/pages/CompetitionDetail.tsx
+++ b/frontend/src/pages/CompetitionDetail.tsx
@@ -1,0 +1,38 @@
+import { useCompetition } from '@/features/competitions';
+import { useParams } from 'react-router-dom';
+
+export function CompetitionDetailPage() {
+  const { eid } = useParams<{ eid: string }>();
+  const { data: competition, isLoading } = useCompetition(eid);
+
+  if (isLoading) {
+    return <div className="py-4 text-center">Loading competition...</div>;
+  }
+
+  if (!competition) {
+    return (
+      <div className="py-4 text-center text-muted-foreground">
+        Competition not found
+      </div>
+    );
+  }
+
+  const formatDate = (date: Date) =>
+    new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(date));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">{competition.name}</h1>
+        <p className="text-muted-foreground">
+          {formatDate(competition.startDate)} • {competition.organization.name}
+        </p>
+      </div>
+      {competition.description && <p>{competition.description}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Competitions.tsx
+++ b/frontend/src/pages/Competitions.tsx
@@ -1,0 +1,18 @@
+import { CompetitionsList, useCompetitions } from '@/features/competitions';
+
+export function CompetitionsPage() {
+  const { data: competitions = [], isLoading } = useCompetitions({
+    upcoming: true,
+    past: false,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Competitions</h1>
+        <p className="text-muted-foreground">Upcoming competitions calendar.</p>
+      </div>
+      <CompetitionsList competitions={competitions} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -1,0 +1,18 @@
+import { CompetitionsList, useCompetitions } from '@/features/competitions';
+
+export function ResultsPage() {
+  const { data: competitions = [], isLoading } = useCompetitions({
+    upcoming: false,
+    past: true,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Results</h1>
+        <p className="text-muted-foreground">Past competitions and results.</p>
+      </div>
+      <CompetitionsList competitions={competitions} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -3,3 +3,6 @@ export { default as Home } from './Home';
 export { default as NotFound } from './NotFound';
 export { SignInPage } from './SignIn';
 export { SignUpPage } from './SignUp';
+export { CompetitionsPage } from './Competitions';
+export { ResultsPage } from './Results';
+export { CompetitionDetailPage } from './CompetitionDetail';


### PR DESCRIPTION
## Summary
- expose a competition detail endpoint
- expose competitions list component
- list competitions on calendar and results pages
- allow viewing competition details

## Testing
- `npm run lint` in `frontend`
- `npm run build` in `frontend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685816884dc8832985449115eed9698c