### PR TITLE
Add update route for competition events

### DIFF
--- a/backend/src/routes/organization/competition-events.ts
+++ b/backend/src/routes/organization/competition-events.ts
@@ -6,6 +6,7 @@ import { zValidator } from '@hono/zod-validator';
 import {
   CompetitionEvent$,
   CompetitionEventCreate$,
+  CompetitionEventUpdate$,
   CompetitionEventPrismaCreate$,
   Cuid$,
   competitionEventInclude,
@@ -64,6 +65,67 @@ organizationCompetitionEventsRoutes.post(
     } catch (error) {
       logError('Failed to create competition event', error, c);
       return c.json({ error: 'Failed to create competition event' }, 500);
+    }
+  }
+);
+
+// PUT /organization/competitions/:competitionEid/events/:eventEid - Update competition event
+organizationCompetitionEventsRoutes.put(
+  '/:competitionEid/events/:eventEid',
+  requirePermissions({
+    events: ['update'],
+  }),
+  zValidator(
+    'param',
+    z.object({ competitionEid: Cuid$, eventEid: Cuid$ })
+  ),
+  zValidator('json', CompetitionEventUpdate$),
+  async (c) => {
+    try {
+      const { competitionEid, eventEid } = c.req.valid('param');
+      const { categoryIds, ...updateBody } = c.req.valid('json');
+      const session = await getRequiredSession(c);
+
+      if (!session.activeOrganizationId) {
+        logger.error('No active organization found for user', { session });
+        return c.json({ error: 'No active organization found' }, 400);
+      }
+
+      const competition = await prisma.competition.findFirst({
+        where: { eid: competitionEid, organizationId: session.activeOrganizationId },
+      });
+
+      if (!competition) {
+        return c.json({ error: 'Competition not found' }, 404);
+      }
+
+      const competitionEvent = await prisma.competitionEvent.findFirst({
+        where: { eid: eventEid, competitionId: competition.id },
+      });
+
+      if (!competitionEvent) {
+        return c.json({ error: 'Competition event not found' }, 404);
+      }
+
+      const data: Record<string, unknown> = {
+        ...updateBody,
+        updatedBy: session.userId,
+      };
+
+      if (categoryIds) {
+        data.categories = { set: categoryIds.map((id) => ({ id })) };
+      }
+
+      const updatedCompetitionEvent = await prisma.competitionEvent.update({
+        where: { id: competitionEvent.id },
+        data,
+        include: competitionEventInclude,
+      });
+
+      return c.json(CompetitionEvent$.parse(updatedCompetitionEvent));
+    } catch (error) {
+      logError('Failed to update competition event', error, c);
+      return c.json({ error: 'Failed to update competition event' }, 500);
     }
   }
 );

--- a/core/src/schemas/competition-event.ts
+++ b/core/src/schemas/competition-event.ts
@@ -52,3 +52,7 @@ export const CompetitionEventCreate$ = CompetitionEventPrismaCreate$.omit({
   categoryIds: z.array(ParameterId$).optional(),
 });
 export type CompetitionEventCreate = z.infer<typeof CompetitionEventCreate$>;
+
+// Schema for API competition event update
+export const CompetitionEventUpdate$ = CompetitionEventCreate$.partial();
+export type CompetitionEventUpdate = z.infer<typeof CompetitionEventUpdate$>;


### PR DESCRIPTION
## Summary
- allow updating competition events for an organization
- add `CompetitionEventUpdate` schema in core

## Testing
- `npm run build` in `core`
- `npm run build` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685a9a3932ac83298ac2ba527f64253c